### PR TITLE
Add specific tag to base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION       0.2
 # DOCKER-VERSION        0.4
-FROM    phusion/baseimage
+FROM    phusion/baseimage:0.9.18
 MAINTAINER Ernesto Rodriguez Ortiz <ernesto.rodriguezortiz@savoirfairelinux.com>
 
 # Set correct environment variables.


### PR DESCRIPTION
Tag 0.9.18 is latest tag with Ubuntu 14.x on which this image is based.
